### PR TITLE
Add new tutorial for installing Docker and CloudForest.

### DIFF
--- a/_posts/2021-05-20-CRA-tutorial.md
+++ b/_posts/2021-05-20-CRA-tutorial.md
@@ -1,8 +1,8 @@
 ---
-title: "Installing CloudForest, and utilizing the Cipres Rest API to infer trees"
+title: "Utilizing the Cipres Rest API to infer trees"
 date: 20-May-2021
 categories:
-  - Getting Started
+  - Analyzing Data
 tags:
   - Jekyll
   - update
@@ -10,24 +10,19 @@ youtubeId: iKRTPDBHynw
 ---
 {% include youtubePlayer.html id=page.youtubeId %}
 
-##### 1. Install and run Docker
-Installation directions vary by operating system. Detailed instructions can be found [here](https://docs.docker.com/get-docker/). Once downloaded and run, Docker runs in the background. 
-  
-***NOTE:*** *If using Windows, it is recommended to download and install a ***WSL 2*** linux instance on your computer for easier integration with Docker upon install. More details on installing ***WSL 2*** can be found [here](https://www.omgubuntu.co.uk/how-to-install-wsl2-on-windows-10).*  
-  
-##### 2. Create a Cipres Rest API account
+##### 1. Create a Cipres Rest API account
 Registration can be completed [here](https://www.phylo.org/restusers/register.action). After your account is created, no further account configuration is necessary. *The credentials you create in this step will be used by CloudForest for remote job submission.*
 
 ***NOTE:*** *Steps 3-4 are necessary in the Beta release of CloudForest, but will not be present in the final release. Instead, CloudForest will be packaged for easy installation and running*
 
-##### 3. Clone and Navigate to the CloudForestDocker repository
+##### 2. Clone and Navigate to the CloudForestDocker repository
 Once Docker is installed and is running in the background, navigate to your preferred directory from a Unix command line and run the following commands:  
 ```
 $ git clone -b beta_testing https://github.com/TreeScaper/CloudforestDocker.git
 $ cd CloudforestDocker  
 ```
 
-##### 4. Run CloudForest
+##### 3. Run CloudForest
 From within the CloudForestDocker directory, run the following command:  
 ```
 $ ./run.sh --tag beta_testing
@@ -38,12 +33,12 @@ After running the command, you will be prompted for your CRA credentials.
 
 ***NOTE:*** *Because this step passes information to your machine’s Docker application unencrypted, this should only be performed on a personal computer. Solutions are in the works for a fully secure method of providing third-party credentials to the framework underlying CloudForest.*
 
-##### 5. Open CloudForest
+##### 4. Open CloudForest
 CloudForest runs as a web server within the Galaxy Framework. ~20 seconds after the installation command finsihes, navigate to http://localhost:8080 within your browser to access CloudForest.
 
 ***NOTE:*** *The remaining steps of the tutorial will carry out a sample analysis to conduct maximum likelihood analysis via IQTree for a set of alignments. To follow along, download the data [here](https://github.com/TreeScaper/TreeScaper.github.io/blob/master/sample_data/turtles_alignments.zip)*
 
-##### 6. Upload Data
+##### 5. Upload Data
 The lefthand side of the Galaxy interface is the Tool Panel. After you download and decompress the sample data, follow these steps to upload the individual alignments:
 - Expand the **Get Data** tab
 - Open the **Upload File** tool
@@ -55,7 +50,7 @@ The lefthand side of the Galaxy interface is the Tool Panel. After you download 
     On the right-hand side you will see new history items for your files. Each of these (if you uploaded multiple files) represents both the Galaxy job that handled the upload, as well as the uploaded file.
     Input data should be formatted according to the specifications of your program of choice. Here, our sample data takes the Fasta format.
 
-##### 7. Create a Collection
+##### 6. Create a Collection
 By grouping multiple files into a collection, we can pass them more easily as one unit to a single Galaxy job. To create a collection of your sequence files:
 - Click the checkbox above the history of the items labeled *Operations on Multiple Datasets* (pictured below)
 
@@ -66,14 +61,14 @@ By grouping multiple files into a collection, we can pass them more easily as on
 - Name the list (also referred to as a **Collection**) however you like, and select **Create List**.
 - Click the **Operations on multiple datasets** checkbox again to collapse the view.
 
-##### 8. Open the TreeScaper-CRA tool
+##### 7. Open the TreeScaper-CRA tool
 Expand the **CloudForest** category in the tool panel and select **TreeScaper-CRA**.
-##### 9. Select tool and parameters
+##### 8. Select tool and parameters
 Multiple tools for tree inference are available, each with its own list of optional parameters. For the purposes of this tutorial, we will be using IQTree.
 Once the tool is selected, you may adjust the optional parameters to best suit your analysis.
 For the first parameter, **Collection of PHYLIP files**, select the list you created in **Step 7**.
 You may leave the **Status file output** parameter blank for now.
-##### 10. Execute the job
+##### 9. Execute the job
 Once all optional parameters are tuned to your liking, select **Execute** to submit the job. New jobs will populate the **History** panel on the right side of the screen. Each job will turn yellow upon execution, and green upon completion. If a given job fails, it will turn red. Multiple outputs will be created by this job:
 - **Parameters**: Copy of the parameters file used by TreeScaper.
 - **Job Status**: File that lists each job with fields for the input file, status, and job ID within CRA. In addition to allowing the user to investigate a job further using the CRA, this file can also be input into the tool in the event of an interruption to begin where the previous run left off.

--- a/_posts/2023-06-15-install-tutorial.md
+++ b/_posts/2023-06-15-install-tutorial.md
@@ -19,7 +19,7 @@ Installers are located in the following repository: https://github.com/TreeScape
 ###### (MacOS)
 1. Download **launchers/cloudforest_launchor_macos_v0.0.x.zip** from the workshop repository.
 2. Double click to extract into Downloads folder.
-3. Right-click CloudForest.command file and select Open.
+3. Right-click or control-click the CloudForest.command file and select Open.
 4. Select Open on warning screen.
 
 ###### (Windows)
@@ -34,4 +34,4 @@ CloudForest runs as a web server within Docker. One minute after the launch proc
 You may close the window that popped up when starting CloudForest.
 
 ##### 4. Update or Close CloudForest
-Because CloudForest runs in the background, separate commands are used to restart and close CloudForest, also located in the same folder as the command used to start CloudForest. Every time CloudForest is started or restarted with these files it will pull the latest updates, so the restart command may be used for this purpose.
+To stop or restart CloudForest, run the **StopCloudForest** and **RestartCloudForest** files (**StopCloudForest.command** and **RestartCloudForest.command** on MacOS). Every time CloudForest is started or restarted it will pull the latest updates, so you may run **RestartCloudForest** to update CloudForest as well.

--- a/_posts/2023-06-15-install-tutorial.md
+++ b/_posts/2023-06-15-install-tutorial.md
@@ -1,0 +1,37 @@
+---
+title: "Installing CloudForest"
+date: 15-June-2023
+categories:
+  - Getting Started
+tags:
+  - Jekyll
+  - update
+---
+
+##### 1. Install and run Docker
+Installation directions vary by operating system. Detailed instructions can be found [here](https://docs.docker.com/get-docker/). Once downloaded and run, Docker runs in the background.
+
+***NOTE:*** *If using Windows, it is recommended to download and install a ***WSL 2*** linux instance on your computer for easier integration with Docker upon install. More details on installing ***WSL 2*** can be found [here](https://www.omgubuntu.co.uk/how-to-install-wsl2-on-windows-10).*
+
+##### 2. Install CloudForest
+Installers are located in the following repository: https://github.com/TreeScaper/SSBWorkshop_2023.
+
+###### (MacOS)
+1. Download **launchers/cloudforest_launchor_macos_v0.0.x.zip** from the workshop repository.
+2. Double click to extract into Downloads folder.
+3. Right-click CloudForest.command file and select Open.
+4. Select Open on warning screen.
+
+###### (Windows)
+1. Download **launchers/cloudforest_launchor_windows_v0.0.x.zip** from the workshop repository.
+2. Extract all into Downloads folder.
+3. Double-click CloudForest file.
+4. Click “More info” on Windows warning, then click “Run anyway”.
+
+##### 3. Open CloudForest
+CloudForest runs as a web server within Docker. One minute after the launch process has finished, navigate to http://localhost:8080 within your browser to access CloudForest.
+
+You may close the window that popped up when starting CloudForest.
+
+##### 4. Update or Close CloudForest
+Because CloudForest runs in the background, separate commands are used to restart and close CloudForest, also located in the same folder as the command used to start CloudForest. Every time CloudForest is started or restarted with these files it will pull the latest updates, so the restart command may be used for this purpose.


### PR DESCRIPTION
New tutorial uses current, temporary install scripts, and is included under **Getting Started**. CRA tutorial modified to remove Docker installation directions and moved to **Analyzing Data** category.